### PR TITLE
revocation logic

### DIFF
--- a/src/VoteDelegate.t.sol
+++ b/src/VoteDelegate.t.sol
@@ -315,7 +315,7 @@ contract VoteDelegateTest is DSTest {
    function testFail_revoke_not_allowed() public {
         (Revoker revoker, ) = revoke_setup();
         Revoker otherRevoker = new Revoker();
-        assertTrue(address(otherRevoker) == address(revoker));
+        assertTrue(address(otherRevoker) != address(revoker));
         otherRevoker.revoke(proxy, address(delegator1));
    }
 }


### PR DESCRIPTION
Adds a hook that allows arbitrary delegation revocation logic to be built on top via another smart contract for delegators wishing to opt-in to such a feature. Can be considered a safeguard against the `VoteDelegate` becoming a more permanent solution than originally intended.

I favor this over a hardcoded expiration because:
1) a hardcoded expiration sets us up for a painful last-minute scramble if the governance system isn't upgraded in time
2) a fixed expiration may be too inflexible.

I favor this over no expiration because:
1) otherwise there's no defense against the lost keys/hit-by-bus/etc scenario besides a complete system upgrade.